### PR TITLE
feat: friendlier error message for missing package.json

### DIFF
--- a/lua/telescope/_extensions/node_modules_builtin.lua
+++ b/lua/telescope/_extensions/node_modules_builtin.lua
@@ -105,6 +105,7 @@ M.list = function(opts)
   local info = package_info(opts.cwd)
   if not info then
     vim.notify("package.json not found", vim.log.levels.WARN)
+    return
   end
   local deps = dependencies(info.json)
 

--- a/lua/telescope/_extensions/node_modules_builtin.lua
+++ b/lua/telescope/_extensions/node_modules_builtin.lua
@@ -103,7 +103,9 @@ M.list = function(opts)
   )
 
   local info = package_info(opts.cwd)
-  if not info then error('cannot find package.json') end
+  if not info then
+    vim.notify("package.json not found", vim.log.levels.WARN)
+  end
   local deps = dependencies(info.json)
 
   local function process_dir(results, dir)


### PR DESCRIPTION
Current:
![image](https://user-images.githubusercontent.com/62098008/166501765-195954a3-757d-463f-aaf8-68ccf45f5da9.png)

The current `error` thrown with missing `package.json` files is not very user-friendly, with unnecessary error traces. Displaying a warning should be adequate in alerting the user of the reason causing the error.